### PR TITLE
Truncate existing files when overwriting

### DIFF
--- a/src/DocumentSaver.cpp
+++ b/src/DocumentSaver.cpp
@@ -79,7 +79,7 @@ void DocumentSaver::savePDF(const QUrl &fileUrl, const SkanpageUtils::DocumentPa
 {
     const QString localName = getLocalNameForFile(fileUrl);
     QFile file(localName);
-    bool ok = file.open(QIODevice::ReadWrite);
+    bool ok = file.open(QIODevice::WriteOnly);
     if (!ok) {
         Q_EMIT showUserMessage(SkanpageUtils::ErrorMessage, i18nc("%1 is the error message", "An error ocurred while saving: %1.", file.errorString()));
         return;


### PR DESCRIPTION
WriteOnly mode truncates existing files when overwriting, but ReadWrite does not.
https://doc.qt.io/qt-6/qiodevicebase.html

This resolves an issue where sensitive data may still remain in a file that has been overwritten by skanpage.

This resolves https://bugs.kde.org/show_bug.cgi?id=507174.

This change has been tested with the same example used in the bug report and correctly truncates the file. The output file is correctly shortened from 28797225 bytes to 998742 with a one-page scan, and `binwalk` shows no extra pages:

```
-----------------------------------------------------------------------------------------
DECIMAL                            HEXADECIMAL                        DESCRIPTION
-----------------------------------------------------------------------------------------
0                                  0x0                                PDF document, 
                                                                      version 1.4
2027                               0x7EB                              JPEG image, total 
                                                                      size: 995371 bytes
-----------------------------------------------------------------------------------------
```